### PR TITLE
Remove all allocations in phase_vels

### DIFF
--- a/src/velocities.jl
+++ b/src/velocities.jl
@@ -124,7 +124,7 @@ function make_T(C, x)
         n = ijkl[k,l]
         T[i,k] = T[i,k] + C[m,n]*x[j]*x[l]
     end
-    return LinearAlgebra.Hermitian(T) # Real-symmetric
+    return LinearAlgebra.Hermitian(SMatrix(T)) # Real-symmetric
 end
 
 "Return a 3-vector which is the cartesian direction corresponding to


### PR DESCRIPTION
Speed up `phase_vels` slightly by removing all allocations.  This is
done by converting the `MMatrix` in `make_T` into an `SMatrix` before
returning, and this removes the heap allocation it previously caused.
