### PR TITLE
Makie: Update compat and fix bug with Makie v0.24

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ CIJMakieExt = ["GeometryBasics", "Makie"]
 
 [compat]
 GeometryBasics = "0.4, 0.5"
-Makie = "0.21, 0.22"
+Makie = "0.21, 0.22, 0.23, 0.24"
 Rotations = "1"
 StaticArrays = "0.12, 1"
 julia = "1.6"

--- a/ext/CIJMakieExt.jl
+++ b/ext/CIJMakieExt.jl
@@ -480,12 +480,20 @@ segment is centred around `points` but has two ends either side, and its
 orientation is determined by `vectors`.
 """
 function _vector_lines(vectors, points; point_scale=1.01, vector_scale=0.1)
+    # Work around https://github.com/MakieOrg/Makie.jl/issues/5298
+    # and avoid creating a `Vector{Makie.Point3}`, since `Point3` is a
+    # `UnionAll` and not a concrete type, and at present Makie can't
+    # convert that automatically for plotting.
+    V = eltype(first(vectors))
+    P = eltype(first(vectors))
+    T = promote_type(V, P, typeof(point_scale), typeof(vector_scale))
     # TODO: Replace with a version using `GeometryBasics.LineString`s?
     Iterators.flatten(
         (
             point_scale*p + vector_scale*x,
             point_scale*p - vector_scale*x,
-            GeometryBasics.Point3(NaN32, NaN32, NaN32)
+            # Avoid creating a UnionAll
+            GeometryBasics.Point3{T}(NaN32, NaN32, NaN32)
         )
         for (x, p) in zip(vectors, points)
     ) |> collect


### PR DESCRIPTION
Increase compat bounds up to Makie v0.24.

Makie up to at least v0.24.6 has a bug where it no longer plots vectors
of `UnionAll` `Point`s.  (E.g., `Makie.lines(rand(Point3, 10))` fails;
see https://github.com/MakieOrg/Makie.jl/issues/5298.)  Enforce a
concrete eltype of the vectors returned in `CIJMakieExt._vector_lines`
to ensure we don't hit this and ensure plotting in `CIJ.plot_sphere`
still works when plotting directions.

For now, continue to use deprecated `Makie.arrows` commands.  These will
be replaced by calls to `Makie.arrows3d` when we drop support for Makie
versions 0.22 and below.
