### PR TITLE
Fix bug in thom_st

### DIFF
--- a/src/initialisation.jl
+++ b/src/initialisation.jl
@@ -134,15 +134,19 @@ end
     thom_st(vp, vs, eps, gam, delst) -> C
 
 Return the 6x6 Voigt matrix `C` defined by the general anisotropy parameters of
-Thomsen (1986).
+Thomsen (1986), where `delst` is Thomsen's δ*.
 
 Output has same units as input.
+
+### References
+
+Thomsen, L. (1986).  Weak elastic anisotropy.  Geophysics, 51, 10, 1954-1966.
 """
 function thom_st(vp, vs, eps, gam, delst)
     if vp <= 0
-        error("CIJ.thom: vp must be greater than 0")
+        throw(ArgumentError("vp must be greater than 0"))
     elseif vs < 0
-        error("CIJ.thom: vs must be greater than or equal to 0")
+        throw(ArgumentError("vs must be greater than or equal to 0"))
     end
 
     C = zero(EC)
@@ -153,9 +157,9 @@ function thom_st(vp, vs, eps, gam, delst)
         C[6,6] = C[4,4]*(2*gam + 1)
         a = 2.0
         b = 4*C[4,4]
-        c = C[4,4]^2 - 2*delst*C[3,3]^2 - (C[3,3] - C[4,4])*(C[1,1] + C[3,3] - 2*C[4,4])
+        c = 2*C[4,4]^2 - 2*delst*C[3,3]^2 - (C[3,3] - C[4,4])*(C[1,1] + C[3,3] - 2*C[4,4])
         if b^2 - 4*a*c < 0
-            error("CIJ.thom_st: S velocity too high or delta too negative")
+            throw(ArgumentError("S velocity too high or delst too negative"))
         end
         C[1,3] = C[3,1] = C[2,3] = C[3,2] = (-b + sqrt(b^2 - 4*a*c))/(2*a)
         C[1,2] = C[2,1] = C[1,1] - 2C[6,6]

--- a/test/synthesis.jl
+++ b/test/synthesis.jl
@@ -18,4 +18,25 @@ using CIJ, Test
             @test iso(K=K, G=G) == c
         end
     end
+
+    @testset "thom_st" begin
+        @testset "Invalid input" begin
+            @test_throws ArgumentError thom_st(0, 1000, 0, 0, 0)
+            @test_throws ArgumentError thom_st(4000, -1000, 0, 0, 0)
+            @test_throws ArgumentError thom_st(4000, 2000, -1, 0, 0)
+        end
+
+        @testset "Known values" begin
+            c = thom_st(4000, 2000, 0.01, -0.01, 0.03)
+            @test c[1,1] == c[2,2] == 16_320_000
+            @test c[3,3] == 16_000_000
+            @test c[4,4] == c[5,5] == 4_000_000
+            @test c[6,6] == 3_920_000
+            @test c[1,2] == 8_480_000
+            @test c[1,3] ≈ 8_393_546.708 atol=0.001
+            @test c[2,3] == c[1,3]
+            @test c[1,4] == c[1,5] == c[1,6] == c[2,4] == c[2,5] == c[2,6] ==
+                c[3,4] == c[3,5] == c[3,6] == c[4,5] == c[4,6] == c[5,6] == 0
+        end
+    end
 end


### PR DESCRIPTION
There was a missing factor of two for a term in the quadratic
expression in terms of C13, giving wrong values.  Fix this and add
a test.
