### PR TITLE
CI: Fix issue of trying to run x64 on macos-latest

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -26,7 +26,6 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
-          - macos-latest
         arch:
           - x64
         include:
@@ -36,6 +35,12 @@ jobs:
           - os: ubuntu-latest
             version: '1'
             arch: x86
+          - os: macos-latest
+            version: '1'
+            arch: aarch64
+          - os: macos-latest
+            version: 'nightly'
+            arch: aarch64
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
macOS runners on GitHub Actions are of course now aarch64 in terms
of architecture, but we had not updated CI to recognise this.
