### PR TITLE
Speed up transform and return EC from rot3

### DIFF
--- a/src/transformation.jl
+++ b/src/transformation.jl
@@ -5,13 +5,13 @@
 
 Return a rotated tensor `Cr`, the result of rotating in turn the tensor `C`:
 
-1. About the x1 axis by `a` degrees clockwise when looking down the x1 axis
+1. About the x1 axis by `a` degrees **anticlockwise** when looking down the x1 axis
 2.   "    "  x2   "   " `b`    "        "       "     "      "   "  x2   "
 3.   "    "  x3   "   " `b`    "        "       "     "      "   "  x3   "
 
 Rotations are performed in that order,
 """
-rot3(C, a, b, c) = transform(C, RotXYZ(deg2rad(a), deg2rad(b), deg2rad(c)))
+rot3(C, a, b, c) = EC(transform(C, RotXYZ(deg2rad(a), deg2rad(b), deg2rad(c))))
 
 """
     transform(C, M) -> C′
@@ -20,7 +20,7 @@ Apply a transformation matrix `M` to a 6x6 matrix `C`, returning the transformed
 """
 function transform(C, M)
     K = _transformation_matrix(M)
-    return K * (C * transpose(K))
+    return K * (SMatrix{6,6}(C) * transpose(K))
 end
 
 """
@@ -29,8 +29,8 @@ end
 Return the matrix `K` which represents the matrix with which to transform a Voigt
 6x6 matrix by the 3x3 transformation matrix `M`.
 """
-@inline function _transformation_matrix(M)
-    K = MMatrix{6, 6, Float64}(undef)
+function _transformation_matrix(M::AbstractMatrix{T}) where T
+    K = MMatrix{6, 6, T}(undef)
     @inbounds for i = 1:3
         i1 = (i + 1)%3
         i1 = i1 == 0 ? 3 : i1
@@ -47,5 +47,5 @@ Return the matrix `K` which represents the matrix with which to transform a Voig
             K[i+3,j+3] = M[i1,j1]*M[i2,j2] + M[i1,j2]*M[i2,j1]
         end
     end
-    K
+    SMatrix(K)
 end

--- a/test/transformation.jl
+++ b/test/transformation.jl
@@ -1,0 +1,36 @@
+using CIJ
+using Test
+
+@testset "Transformations" begin
+    @testset "rot3" begin
+        c = CIJ.rot3(CIJ.ol()[1], 180rand(), 180rand(), 180rand())
+
+        @testset "Identity" begin
+            @test c ≈ rot3(c, 0, 0, 0)
+            @test c ≈ rot3(c, 360, 0, 0)
+            @test c ≈ rot3(c, 0, 360, 0)
+            @test c ≈ rot3(c, 0, 0, 360)
+        end
+
+        rot_angle = 30
+
+        @testset "x1" begin
+            c′ = rot3(c, rot_angle, 0, 0)
+            @test phase_vels(c, 0, 0).pol ≈ phase_vels(c′, 0, 0).pol + rot_angle atol=0.1
+        end
+
+        @testset "x2" begin
+            c′ = rot3(c, 0, rot_angle, 0)
+            @test phase_vels(c, -90, 0).pol ≈ phase_vels(c′, -90, 0).pol + rot_angle atol=0.1
+        end
+
+        @testset "x3" begin
+            c′ = rot3(c, 0, 0, rot_angle)
+            @test phase_vels(c, 0, 90).pol ≈ phase_vels(c′, -rot_angle, 90).pol atol=0.1
+        end
+
+        @testset "Allocations" begin
+            @test Base.@allocations(rot3(c, rand(), rand(), rand())) == 0
+        end
+    end
+end


### PR DESCRIPTION
Speed up `CIJ.transform` by always returning an `SMatrix{6,6}`
from `CIJ._transformation_matrix`.  This reduces the number of
allocations in `transform` when we convert `C` into an `SMatrix`
as well, meaning `rot3` only allocates once to return an `EC`
version of the input.  Reduces allocations from 5 to 1.
