### PR TITLE
Fix bug in pitl

### DIFF
--- a/src/effective_medium.jl
+++ b/src/effective_medium.jl
@@ -18,6 +18,9 @@ by two periodic layers where each layer `i` is defined by:
 """
 function pitl(d1, vp1, vs1, rho1, d2, vp2, vs2, rho2)
     C = zero(EC)
+    d1, vp1, vs1, rho1, d2, vp2, vs2, rho2, _ = promote(
+        d1, vp1, vs1, rho1, d2, vp2, vs2, rho2, zero(eltype(C))
+    )
     # Lamé parameters from velocities
     m1 = rho1*vs1^2
     m2 = rho2*vs2^2
@@ -42,7 +45,7 @@ function pitl(d1, vp1, vs1, rho1, d2, vp2, vs2, rho2)
     end
     # Normalise back to average density
     rho = (d1*rho1 + d2*rho2)/(d1 + d2)
-    C ./= rho
+    C = EC(C./rho)
     return C, rho
 end
 

--- a/test/effective_medium.jl
+++ b/test/effective_medium.jl
@@ -2,6 +2,23 @@ using CIJ
 using Test
 
 @testset "Effective media" begin
+    @testset "pitl" begin
+        C, ρ = CIJ.pitl(0.1, 2000, 1000, 1500, 0.01, 1500, 100, 1000)
+        @test ρ ≈ (0.1*1500 + 0.01*1000)/0.11
+        @test all(
+            .≈(
+                C,
+                [ 3.87762e6  2.00137e6  1.95105e6      0.0      0.0       0.0
+                  2.00137e6  3.87762e6  1.95105e6      0.0      0.0       0.0
+                  1.95105e6  1.95105e6  3.58224e6      0.0      0.0       0.0
+                  0.0        0.0        0.0        70898.4      0.0       0.0
+                  0.0        0.0        0.0            0.0  70898.4       0.0
+                  0.0        0.0        0.0            0.0      0.0  938125.0];
+                  atol=100
+            )
+        )
+    end
+
     @testset "tandon_and_weng" begin
         @testset "Water-filled cracks" begin
             C, ρ = tandon_and_weng(3240, 1800, 3800, 0.01, 0.01, 1500, 0, 1000)


### PR DESCRIPTION
`pitl` had the same error in using in-place division as `tandon_and_weng` (0ab8653430d17288baeb7dea3a3cf36fe7b2b159). Fix this in the same way.